### PR TITLE
aws-es: add putMapping and getMapping

### DIFF
--- a/lib/aws-es.js
+++ b/lib/aws-es.js
@@ -110,6 +110,27 @@ AWSES.prototype._request = function(path, body, options, callback) {
     req.end(opts.body || '');
 };
 
+AWSES.prototype.createIndex = function(options, callback) {
+    var self = this;
+
+    if( !is.existy(callback) ) throw new Error('not_callback');
+    if( !is.function(callback) ) throw new Error('invalid_callback');
+
+    if( !is.existy(options) ) return callback('not_options');
+    if( !is.json(options) ) return callback('invalid_options');
+
+    if( !is.existy(options.name) ) return callback('not_index');
+    if( !is.string(options.name) ) return callback('invalid_index');
+
+    if( is.existy(options.body) && !is.json(options.body) ) return callback('invalid_body');
+
+    var path = '/' + options.name;
+    self._request(path, options.body || {}, {method: 'PUT'}, function(err, data) {
+        if(err) return callback(err);
+        return callback(null, data);
+    });
+};
+
 AWSES.prototype.count = function(options, callback) {
     var self = this;
 

--- a/lib/aws-es.js
+++ b/lib/aws-es.js
@@ -446,4 +446,65 @@ AWSES.prototype.delete = function(options, callback) {
     });
 };
 
+AWSES.prototype.putMapping = function(options, callback) {
+    var self = this;
+
+    if( !is.existy(callback) )
+    {
+        if(is.function(options))
+        {
+            callback = options;
+            options = null;
+        }
+    }
+
+    if( !is.existy(callback) ) throw new Error('not_callback');
+    if( !is.function(callback) ) throw new Error('invalid_callback');
+
+    if( !is.existy(options.type) ) return callback('not_type');
+    if( !is.string(options.type) ) return callback('invalid_type');
+
+    if( !is.existy(options.body) ) return callback('not_body');
+    if( !is.json(options.body) ) return callback('invalid_body');
+
+    var path = '/';
+    if (options.index)
+        path += '/'+options.index;
+
+    path += '/_mapping/'+options.type;
+    self._request(path, options.body, {method: 'POST'}, function(err, data) {
+        if(err) return callback(err);
+        return callback(null, data);
+    });
+};
+
+AWSES.prototype.getMapping = function(options, callback) {
+    var self = this;
+
+    if( !is.existy(callback) )
+    {
+        if(is.function(options))
+        {
+            callback = options;
+            options = null;
+        }
+    }
+
+    if( !is.existy(callback) ) throw new Error('not_callback');
+    if( !is.function(callback) ) throw new Error('invalid_callback');
+
+    if( !is.existy(options.type) ) return callback('not_type');
+    if( !is.string(options.type) ) return callback('invalid_type');
+
+    var path = '/';
+    if (options.index)
+        path += '/'+options.index;
+
+    path += '/_mapping/'+options.type;
+    self._request(path, options.body, {method: 'GET'}, function(err, data) {
+        if(err) return callback(err);
+        return callback(null, data);
+    });
+};
+
 module.exports = AWSES;

--- a/test/lib/aws-esSpec.js
+++ b/test/lib/aws-esSpec.js
@@ -1208,6 +1208,34 @@ describe('aws-es', function() {
         });
     });
 
+	describe('mappings', function() {
+		it('puts a mapping and retrieves it', function(done) {
+			elasticsearch.putMapping({
+				index: INDEX,
+				type: TYPE,
+				body: {
+					properties: {
+						new_property: {
+							type: 'string'
+						}
+					}
+				}
+			}, function(err, data) {
+				expect(err).to.be.null;
+				expect(data.acknowledged).equal(true);
+				elasticsearch.getMapping({
+					index: INDEX,
+					type: TYPE
+				}, function(err, data) {
+					expect(err).to.be.null;
+					expect(data[INDEX].mappings[TYPE].properties.new_property)
+						.deep.equal({type: 'string'});
+					done();
+				});
+			});
+		});
+	});
+
 	describe('delete', function() {
 
         it('should throw an error for no callback', function() {

--- a/test/lib/aws-esSpec.js
+++ b/test/lib/aws-esSpec.js
@@ -222,6 +222,42 @@ describe('aws-es', function() {
         });
     });
 
+	describe('createIndex', function() {
+		var index = 'test_create_index_index';
+		after(function(done) {
+			elasticsearch.delete({
+				index: index
+			}, done);
+		});
+
+		it('creates an index with a mapping', function(done) {
+			var mapping = {
+				mappings: {
+					bananas: {
+						properties: {
+							pajamas: {
+								type: 'string',
+								index: 'not_analyzed'
+							}
+						}
+					}
+				}
+			};
+			elasticsearch.createIndex({
+				name: index,
+				body: mapping
+			}, function(err, data) {
+				elasticsearch.getMapping({
+					index: index,
+					type: ''
+				}, function(err, data) {
+					expect(data[index]).deep.equal(mapping)
+					done();
+				});
+			});
+		});
+	});
+
     describe('count', function() {
 
         it('should throw an error for no callback', function() {

--- a/test/lib/aws-esSpec.js
+++ b/test/lib/aws-esSpec.js
@@ -3,11 +3,11 @@ var is = require('is_js');
 var AWSES = require(__dirname + '/../../lib/aws-es');
 
 var config = {
-	accessKeyId: 'KEY',
-	secretAccessKey: 'SECRET',
+	accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+	secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     service: 'es',
-    region: 'REGION',
-	host: 'DOMAIN_ENDPOINT'
+    region: 'us-west-2',
+	host: 'search-dave-6jy2cskdfaye4ji6gfa6x375ve.us-west-2.es.amazonaws.com'
 };
 var INDEX = 'testindex';
 var TYPE = 'posts';


### PR DESCRIPTION
We need this to fix https://github.com/juttle/juttle-elastic-adapter/issues/26 and https://github.com/juttle/juttle-elastic-adapter/issues/62. I endeavored to match the ambient code style.
@juttle/developers 
