### PR TITLE
Unify APIs

### DIFF
--- a/lib/aws-es.js
+++ b/lib/aws-es.js
@@ -135,10 +135,7 @@ AWSES.prototype.createIndex = function(options, callback) {
     if (is.existy(options.body) && !is.json(options.body)) return callback('invalid_body');
 
     var path = '/' + options.index;
-    this._request(path, options.body || {}, {method: 'PUT'}, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, options.body || {}, {method: 'PUT'}, callback);
 };
 
 AWSES.prototype.count = function(options, callback) {
@@ -155,10 +152,7 @@ AWSES.prototype.count = function(options, callback) {
     if (is.existy(options.body) && !is.json(options.body)) return callback('invalid_body');
 
     var path = '/' + options.index + '/' + options.type + '/_count';
-    this._request(path, options.body, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, options.body, callback);
 };
 
 AWSES.prototype.index = function(options, callback) {
@@ -178,10 +172,7 @@ AWSES.prototype.index = function(options, callback) {
     if (options.id)
         path += '/' + options.id;
 
-    this._request(path, options.body, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, options.body, callback);
 };
 
 AWSES.prototype.update = function(options, callback) {
@@ -196,10 +187,7 @@ AWSES.prototype.update = function(options, callback) {
     if (missing) { return callback(missing); }
 
     var path = '/' + options.index + '/' + options.type + '/' + options.id + '/_update';
-    this._request(path, options.body, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, options.body, callback);
 };
 
 AWSES.prototype.bulk = function(options, callback) {
@@ -216,10 +204,7 @@ AWSES.prototype.bulk = function(options, callback) {
     if (!is.array(options.body) || (options.body.length == 0)) return callback('invalid_body');
 
     var path = '/' + options.index + '/' + options.type + '/_bulk';
-    this._request(path, options.body, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, options.body, callback);
 };
 
 AWSES.prototype.search = function(options, callback) {
@@ -254,10 +239,7 @@ AWSES.prototype.search = function(options, callback) {
     var path = '/' + options.index + '/' + options.type + '/_search';
     path += '/?' + querystring.stringify(qs);
 
-    this._request(path, options.body, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, options.body, callback);
 };
 
 AWSES.prototype.scroll = function(options, callback) {
@@ -273,10 +255,7 @@ AWSES.prototype.scroll = function(options, callback) {
 
     var path = '/_search/scroll?scroll=' + options.scroll + '&scroll_id=' + options.scrollId;
 
-    this._request(path, null, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, null, callback);
 };
 
 AWSES.prototype.get = function(options, callback) {
@@ -291,10 +270,7 @@ AWSES.prototype.get = function(options, callback) {
     if (missing) { return callback(missing); }
 
     var path = '/' + options.index + '/' + options.type + '/' + options.id;
-    this._request(path, null, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, null, callback);
 };
 
 AWSES.prototype.mget = function(options, callback) {
@@ -309,10 +285,7 @@ AWSES.prototype.mget = function(options, callback) {
     if (missing) { return callback(missing); }
 
     var path = '/' + options.index + '/' + options.type + '/_mget';
-    this._request(path, options.body, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, options.body, callback);
 };
 
 AWSES.prototype.delete = function(options, callback) {
@@ -338,10 +311,7 @@ AWSES.prototype.delete = function(options, callback) {
     if (options.id)
         path += '/'+options.id;
 
-    this._request(path, null, {method: 'DELETE'}, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, null, {method: 'DELETE'}, callback);
 };
 
 AWSES.prototype.putMapping = function(options, callback) {
@@ -360,10 +330,7 @@ AWSES.prototype.putMapping = function(options, callback) {
         path += '/'+options.index;
 
     path += '/_mapping/'+options.type;
-    this._request(path, options.body, {method: 'POST'}, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, options.body, {method: 'POST'}, callback);
 };
 
 AWSES.prototype.getMapping = function(options, callback) {
@@ -382,10 +349,7 @@ AWSES.prototype.getMapping = function(options, callback) {
         path += '/'+options.index;
 
     path += '/_mapping/'+options.type;
-    this._request(path, options.body, {method: 'GET'}, function(err, data) {
-        if (err) return callback(err);
-        return callback(null, data);
-    });
+    this._request(path, options.body, {method: 'GET'}, callback);
 };
 
 AWSES.prototype.indexExists = function(options, callback) {

--- a/lib/aws-es.js
+++ b/lib/aws-es.js
@@ -54,8 +54,6 @@ function AWSES(config) {
 };
 
 AWSES.prototype._request = function(path, body, options, callback) {
-    var self = this;
-
     if (!is.existy(callback)) {
         if (is.function(options)) {
             callback = options;
@@ -78,12 +76,12 @@ AWSES.prototype._request = function(path, body, options, callback) {
     if (!is.string(path)) return callback('invalid_path');
 
     var opts = {
-        service: self.config.service,
-        region: self.config.region,
+        service: this.config.service,
+        region: this.config.region,
         headers: {
             'Content-Type': 'application/json'
         },
-        host: self.config.host,
+        host: this.config.host,
         path: path
     }
 
@@ -103,8 +101,8 @@ AWSES.prototype._request = function(path, body, options, callback) {
     aws4.sign(
         opts,
         {
-            accessKeyId: self.config.accessKeyId,
-            secretAccessKey: self.config.secretAccessKey
+            accessKeyId: this.config.accessKeyId,
+            secretAccessKey: this.config.secretAccessKey
         }
     );
 
@@ -129,8 +127,6 @@ AWSES.prototype._request = function(path, body, options, callback) {
 };
 
 AWSES.prototype.createIndex = function(options, callback) {
-    var self = this;
-
     validate_callback(callback);
 
     var missing = are_options_missing(options, 'index');
@@ -139,15 +135,13 @@ AWSES.prototype.createIndex = function(options, callback) {
     if (is.existy(options.body) && !is.json(options.body)) return callback('invalid_body');
 
     var path = '/' + options.index;
-    self._request(path, options.body || {}, {method: 'PUT'}, function(err, data) {
+    this._request(path, options.body || {}, {method: 'PUT'}, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.count = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -161,15 +155,13 @@ AWSES.prototype.count = function(options, callback) {
     if (is.existy(options.body) && !is.json(options.body)) return callback('invalid_body');
 
     var path = '/' + options.index + '/' + options.type + '/_count';
-    self._request(path, options.body, function(err, data) {
+    this._request(path, options.body, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.index = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -186,15 +178,13 @@ AWSES.prototype.index = function(options, callback) {
     if (options.id)
         path += '/' + options.id;
 
-    self._request(path, options.body, function(err, data) {
+    this._request(path, options.body, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.update = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -206,15 +196,13 @@ AWSES.prototype.update = function(options, callback) {
     if (missing) { return callback(missing); }
 
     var path = '/' + options.index + '/' + options.type + '/' + options.id + '/_update';
-    self._request(path, options.body, function(err, data) {
+    this._request(path, options.body, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.bulk = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -228,15 +216,13 @@ AWSES.prototype.bulk = function(options, callback) {
     if (!is.array(options.body) || (options.body.length == 0)) return callback('invalid_body');
 
     var path = '/' + options.index + '/' + options.type + '/_bulk';
-    self._request(path, options.body, function(err, data) {
+    this._request(path, options.body, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.search = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -268,15 +254,13 @@ AWSES.prototype.search = function(options, callback) {
     var path = '/' + options.index + '/' + options.type + '/_search';
     path += '/?' + querystring.stringify(qs);
 
-    self._request(path, options.body, function(err, data) {
+    this._request(path, options.body, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.scroll = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -289,15 +273,13 @@ AWSES.prototype.scroll = function(options, callback) {
 
     var path = '/_search/scroll?scroll=' + options.scroll + '&scroll_id=' + options.scrollId;
 
-    self._request(path, null, function(err, data) {
+    this._request(path, null, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.get = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -309,15 +291,13 @@ AWSES.prototype.get = function(options, callback) {
     if (missing) { return callback(missing); }
 
     var path = '/' + options.index + '/' + options.type + '/' + options.id;
-    self._request(path, null, function(err, data) {
+    this._request(path, null, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.mget = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -329,15 +309,13 @@ AWSES.prototype.mget = function(options, callback) {
     if (missing) { return callback(missing); }
 
     var path = '/' + options.index + '/' + options.type + '/_mget';
-    self._request(path, options.body, function(err, data) {
+    this._request(path, options.body, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.delete = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -360,15 +338,13 @@ AWSES.prototype.delete = function(options, callback) {
     if (options.id)
         path += '/'+options.id;
 
-    self._request(path, null, {method: 'DELETE'}, function(err, data) {
+    this._request(path, null, {method: 'DELETE'}, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.putMapping = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -384,15 +360,13 @@ AWSES.prototype.putMapping = function(options, callback) {
         path += '/'+options.index;
 
     path += '/_mapping/'+options.type;
-    self._request(path, options.body, {method: 'POST'}, function(err, data) {
+    this._request(path, options.body, {method: 'POST'}, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.getMapping = function(options, callback) {
-    var self = this;
-
     if (!is.existy(callback) && is.function(options)) {
         callback = options;
         options = null;
@@ -408,21 +382,20 @@ AWSES.prototype.getMapping = function(options, callback) {
         path += '/'+options.index;
 
     path += '/_mapping/'+options.type;
-    self._request(path, options.body, {method: 'GET'}, function(err, data) {
+    this._request(path, options.body, {method: 'GET'}, function(err, data) {
         if (err) return callback(err);
         return callback(null, data);
     });
 };
 
 AWSES.prototype.indexExists = function(options, callback) {
-    var self = this;
     validate_callback(callback);
 
     if (!is.json(options)) return callback('not_options');
     if (!is.existy(options.index)) return callback('not_options.index');
 
     var path = '/' + options.index;
-    self._request(path, null, {method: 'HEAD'}, function(err, data) {
+    this._request(path, null, {method: 'HEAD'}, function(err, data) {
         if (!data || !data.statusCode) return callback(err);
         var status = data.statusCode;
         var exists = status === ES_INDEX_EXISTS_STATUS_CODE;

--- a/lib/aws-es.js
+++ b/lib/aws-es.js
@@ -6,24 +6,49 @@ var is = require('is_js');
 var ES_INDEX_EXISTS_STATUS_CODE = 200;
 var ES_INDEX_MISSING_STATUS_CODE = 404;
 
+var OPTION_TYPES = {
+    index: 'string',
+    type: 'string',
+    path: 'string',
+    accessKeyId: 'string',
+    secretAccessKey: 'string',
+    service: 'string',
+    region: 'string',
+    host: 'string',
+    id: 'string',
+    scroll: 'string',
+    scrollId: 'string',
+    body: 'json'
+};
+
+function validate_callback(callback) {
+    if( !is.existy(callback) ) throw new Error('not_callback');
+    if( !is.function(callback) ) throw new Error('invalid_callback');
+}
+
+function are_options_missing(options) {
+    if( !is.existy(options) ) { return 'not_options'; }
+    if( !is.json(options) ) { return 'invalid_options'; }
+
+    for (var i = 1; i < arguments.length; i++) {
+        var option = arguments[i];
+        var option_value = options[option];
+
+        if (!is.existy(option_value)) { return 'not_' + option; }
+
+        var type = OPTION_TYPES[option];
+        if (!is[type](option_value)) { return 'invalid_' + option; }
+    }
+}
+
 function AWSES(config) {
-    if( !is.existy(config) ) throw new Error('not_config');
-    if( !is.json(config) ) throw new Error('invalid_config');
+    if( !is.existy(config) ) { throw new Error('not_config'); }
+    if( !is.json(config) ) { throw new Error('invalid_config'); }
 
-    if( !is.existy(config.accessKeyId) ) throw new Error('not_accessKeyId');
-    if( !is.string(config.accessKeyId) ) throw new Error('invalid_accessKeyId');
+    var missing = are_options_missing(config, 'accessKeyId', 'secretAccessKey',
+        'service', 'region', 'host');
 
-    if( !is.existy(config.secretAccessKey) ) throw new Error('not_secretAccessKey');
-    if( !is.string(config.secretAccessKey) ) throw new Error('invalid_secretAccessKey');
-
-    if( !is.existy(config.service) ) throw new Error('not_service');
-    if( !is.string(config.service) ) throw new Error('invalid_service');
-
-    if( !is.existy(config.region) ) throw new Error('not_region');
-    if( !is.string(config.region) ) throw new Error('invalid_region');
-
-    if( !is.existy(config.host) ) throw new Error('not_host');
-    if( !is.string(config.host) ) throw new Error('invalid_host');
+    if (missing) { throw new Error(missing); }
 
     this.config = config;
 };
@@ -50,8 +75,7 @@ AWSES.prototype._request = function(path, body, options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
     if( !is.existy(body) ) body = null;
     if( is.existy(body) && !is.json(body) && !is.array(body) ) return callback('invalid_body');
@@ -116,14 +140,10 @@ AWSES.prototype._request = function(path, body, options, callback) {
 AWSES.prototype.createIndex = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.index) ) return callback('not_index');
-    if( !is.string(options.index) ) return callback('invalid_index');
+    var missing = are_options_missing(options, 'index');
+    if (missing) { return callback(missing); }
 
     if( is.existy(options.body) && !is.json(options.body) ) return callback('invalid_body');
 
@@ -146,17 +166,10 @@ AWSES.prototype.count = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.index) ) return callback('not_index');
-    if( !is.string(options.index) ) return callback('invalid_index');
-
-    if( !is.existy(options.type) ) return callback('not_type');
-    if( !is.string(options.type) ) return callback('invalid_type');
+    var missing = are_options_missing(options, 'index', 'type');
+    if (missing) { return callback(missing); }
 
     if( is.existy(options.body) && !is.json(options.body) ) return callback('invalid_body');
 
@@ -179,22 +192,12 @@ AWSES.prototype.index = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.index) ) return callback('not_index');
-    if( !is.string(options.index) ) return callback('invalid_index');
-
-    if( !is.existy(options.type) ) return callback('not_type');
-    if( !is.string(options.type) ) return callback('invalid_type');
+    var missing = are_options_missing(options, 'index', 'type', 'body');
+    if (missing) { return callback(missing); }
 
     if( is.existy(options.id) && !is.string(options.id) ) return callback('invalid_id');
-
-    if( !is.existy(options.body) ) return callback('not_body');
-    if( !is.json(options.body) ) return callback('invalid_body');
 
     var path = '/' + options.index + '/' + options.type;
     if(options.id)
@@ -218,23 +221,10 @@ AWSES.prototype.update = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.index) ) return callback('not_index');
-    if( !is.string(options.index) ) return callback('invalid_index');
-
-    if( !is.existy(options.type) ) return callback('not_type');
-    if( !is.string(options.type) ) return callback('invalid_type');
-
-    if( !is.existy(options.id) ) return callback('not_id');
-    if( !is.string(options.id) ) return callback('invalid_id');
-
-    if( !is.existy(options.body) ) return callback('not_body');
-    if( !is.json(options.body) ) return callback('invalid_body');
+    var missing = are_options_missing(options, 'index', 'type', 'body', 'id');
+    if (missing) { return callback(missing); }
 
     var path = '/' + options.index + '/' + options.type + '/' + options.id + '/_update';
     self._request(path, options.body, function(err, data) {
@@ -255,17 +245,9 @@ AWSES.prototype.bulk = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
-
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.index) ) return callback('not_index');
-    if( !is.string(options.index) ) return callback('invalid_index');
-
-    if( !is.existy(options.type) ) return callback('not_type');
-    if( !is.string(options.type) ) return callback('invalid_type');
+    validate_callback(callback);
+    var missing = are_options_missing(options, 'index', 'type');
+    if (missing) { return callback(missing); }
 
     if( !is.existy(options.body) ) return callback('not_body');
     if( !is.array(options.body) || (options.body.length == 0) ) return callback('invalid_body');
@@ -289,20 +271,10 @@ AWSES.prototype.search = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.index) ) return callback('not_index');
-    if( !is.string(options.index) ) return callback('invalid_index');
-
-    if( !is.existy(options.type) ) return callback('not_type');
-    if( !is.string(options.type) ) return callback('invalid_type');
-
-    if( !is.existy(options.body) ) return callback('not_body');
-    if( !is.json(options.body) ) return callback('invalid_body');
+    var missing = are_options_missing(options, 'index', 'type', 'body');
+    if (missing) { return callback(missing); }
 
     if( is.existy(options.scroll) && !is.string(options.scroll) ) return callback('invalid_scroll');
     if( is.existy(options.searchType) && !is.string(options.searchType) ) return callback('invalid_searchType');
@@ -343,17 +315,10 @@ AWSES.prototype.scroll = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.scroll) ) return callback('not_scroll');
-    if( !is.string(options.scroll) ) return callback('invalid_scroll');
-
-    if( !is.existy(options.scrollId) ) return callback('not_scrollId');
-    if( !is.string(options.scrollId) ) return callback('invalid_scrollId');
+    var missing = are_options_missing(options, 'scroll', 'scrollId');
+    if (missing) { return callback(missing); }
 
     var path = '/_search/scroll?scroll=' + options.scroll + '&scroll_id=' + options.scrollId;
 
@@ -375,20 +340,10 @@ AWSES.prototype.get = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.index) ) return callback('not_index');
-    if( !is.string(options.index) ) return callback('invalid_index');
-
-    if( !is.existy(options.type) ) return callback('not_type');
-    if( !is.string(options.type) ) return callback('invalid_type');
-
-    if( !is.existy(options.id) ) return callback('not_id');
-    if( !is.string(options.id) ) return callback('invalid_id');
+    var missing = are_options_missing(options, 'index', 'type', 'id');
+    if (missing) { return callback(missing); }
 
     var path = '/' + options.index + '/' + options.type + '/' + options.id;
     self._request(path, null, function(err, data) {
@@ -409,20 +364,10 @@ AWSES.prototype.mget = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.index) ) return callback('not_index');
-    if( !is.string(options.index) ) return callback('invalid_index');
-
-    if( !is.existy(options.type) ) return callback('not_type');
-    if( !is.string(options.type) ) return callback('invalid_type');
-
-    if( !is.existy(options.body) ) return callback('not_body');
-    if( !is.json(options.body) ) return callback('invalid_body');
+    var missing = are_options_missing(options, 'index', 'type', 'body');
+    if (missing) { return callback(missing); }
 
     var path = '/' + options.index + '/' + options.type + '/_mget';
     self._request(path, options.body, function(err, data) {
@@ -443,14 +388,10 @@ AWSES.prototype.delete = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options) ) return callback('not_options');
-    if( !is.json(options) ) return callback('invalid_options');
-
-    if( !is.existy(options.index) ) return callback('not_index');
-    if( !is.string(options.index) ) return callback('invalid_index');
+    var missing = are_options_missing(options, 'index');
+    if (missing) { return callback(missing); }
 
     if( is.existy(options.type) && !is.string(options.type) ) return callback('invalid_type');
 
@@ -482,14 +423,10 @@ AWSES.prototype.putMapping = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options.type) ) return callback('not_type');
-    if( !is.string(options.type) ) return callback('invalid_type');
-
-    if( !is.existy(options.body) ) return callback('not_body');
-    if( !is.json(options.body) ) return callback('invalid_body');
+    var missing = are_options_missing(options, 'type', 'body');
+    if (missing) { return callback(missing); }
 
     var path = '/';
     if (options.index)
@@ -514,11 +451,10 @@ AWSES.prototype.getMapping = function(options, callback) {
         }
     }
 
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
-    if( !is.existy(options.type) ) return callback('not_type');
-    if( !is.string(options.type) ) return callback('invalid_type');
+    var missing = are_options_missing(options, 'type');
+    if (missing) { return callback(missing); }
 
     var path = '/';
     if (options.index)
@@ -533,8 +469,7 @@ AWSES.prototype.getMapping = function(options, callback) {
 
 AWSES.prototype.indexExists = function(options, callback) {
     var self = this;
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    validate_callback(callback);
 
     if (!is.json(options)) return callback('not_options');
     if (!is.existy(options.index)) return callback('not_options.index');

--- a/lib/aws-es.js
+++ b/lib/aws-es.js
@@ -51,7 +51,14 @@ function AWSES(config) {
     if (missing) { throw new Error(missing); }
 
     this.config = config;
-};
+
+    this.indices = {
+        exists: this.indexExists.bind(this),
+        create: this.createIndex.bind(this),
+        getMapping: this.getMapping.bind(this),
+        delete: this.delete.bind(this),
+    };
+}
 
 AWSES.prototype._request = function(path, body, options, callback) {
     if (!is.existy(callback)) {

--- a/lib/aws-es.js
+++ b/lib/aws-es.js
@@ -22,13 +22,13 @@ var OPTION_TYPES = {
 };
 
 function validate_callback(callback) {
-    if( !is.existy(callback) ) throw new Error('not_callback');
-    if( !is.function(callback) ) throw new Error('invalid_callback');
+    if (!is.existy(callback)) throw new Error('not_callback');
+    if (!is.function(callback)) throw new Error('invalid_callback');
 }
 
 function are_options_missing(options) {
-    if( !is.existy(options) ) { return 'not_options'; }
-    if( !is.json(options) ) { return 'invalid_options'; }
+    if (!is.existy(options)) { return 'not_options'; }
+    if (!is.json(options)) { return 'invalid_options'; }
 
     for (var i = 1; i < arguments.length; i++) {
         var option = arguments[i];
@@ -42,8 +42,8 @@ function are_options_missing(options) {
 }
 
 function AWSES(config) {
-    if( !is.existy(config) ) { throw new Error('not_config'); }
-    if( !is.json(config) ) { throw new Error('invalid_config'); }
+    if (!is.existy(config)) { throw new Error('not_config'); }
+    if (!is.json(config)) { throw new Error('invalid_config'); }
 
     var missing = are_options_missing(config, 'accessKeyId', 'secretAccessKey',
         'service', 'region', 'host');
@@ -56,20 +56,14 @@ function AWSES(config) {
 AWSES.prototype._request = function(path, body, options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
+    if (!is.existy(callback)) {
+        if (is.function(options)) {
             callback = options;
             options = null;
-        }
-        else if(is.function(body))
-        {
+        } else if (is.function(body)) {
             callback = body;
             body = null;
-        }
-        else if(is.function(path))
-        {
+        } else if (is.function(path)) {
             callback = path;
             path = null;
         }
@@ -77,11 +71,11 @@ AWSES.prototype._request = function(path, body, options, callback) {
 
     validate_callback(callback);
 
-    if( !is.existy(body) ) body = null;
-    if( is.existy(body) && !is.json(body) && !is.array(body) ) return callback('invalid_body');
+    if (!is.existy(body)) body = null;
+    if (is.existy(body) && !is.json(body) && !is.array(body)) return callback('invalid_body');
 
-    if( !is.existy(path) ) return callback('not_path');
-    if( !is.string(path) ) return callback('invalid_path');
+    if (!is.existy(path)) return callback('not_path');
+    if (!is.string(path)) return callback('invalid_path');
 
     var opts = {
         service: self.config.service,
@@ -93,12 +87,9 @@ AWSES.prototype._request = function(path, body, options, callback) {
         path: path
     }
 
-    if(body && is.json(body))
-    {
+    if (body && is.json(body)) {
         opts.body = JSON.stringify(body);
-    }
-    else if(body && is.array(body))
-    {
+    } else if (body && is.array(body)) {
         opts.body = '';
         body.forEach(function(obj) {
             opts.body += JSON.stringify(obj);
@@ -106,7 +97,7 @@ AWSES.prototype._request = function(path, body, options, callback) {
         });
     }
 
-    if(options && options.method)
+    if (options && options.method)
         opts.method = options.method;
 
     aws4.sign(
@@ -145,11 +136,11 @@ AWSES.prototype.createIndex = function(options, callback) {
     var missing = are_options_missing(options, 'index');
     if (missing) { return callback(missing); }
 
-    if( is.existy(options.body) && !is.json(options.body) ) return callback('invalid_body');
+    if (is.existy(options.body) && !is.json(options.body)) return callback('invalid_body');
 
     var path = '/' + options.index;
     self._request(path, options.body || {}, {method: 'PUT'}, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -157,13 +148,9 @@ AWSES.prototype.createIndex = function(options, callback) {
 AWSES.prototype.count = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -171,11 +158,11 @@ AWSES.prototype.count = function(options, callback) {
     var missing = are_options_missing(options, 'index', 'type');
     if (missing) { return callback(missing); }
 
-    if( is.existy(options.body) && !is.json(options.body) ) return callback('invalid_body');
+    if (is.existy(options.body) && !is.json(options.body)) return callback('invalid_body');
 
     var path = '/' + options.index + '/' + options.type + '/_count';
     self._request(path, options.body, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -183,13 +170,9 @@ AWSES.prototype.count = function(options, callback) {
 AWSES.prototype.index = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -197,14 +180,14 @@ AWSES.prototype.index = function(options, callback) {
     var missing = are_options_missing(options, 'index', 'type', 'body');
     if (missing) { return callback(missing); }
 
-    if( is.existy(options.id) && !is.string(options.id) ) return callback('invalid_id');
+    if (is.existy(options.id) && !is.string(options.id)) return callback('invalid_id');
 
     var path = '/' + options.index + '/' + options.type;
-    if(options.id)
+    if (options.id)
         path += '/' + options.id;
 
     self._request(path, options.body, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -212,13 +195,9 @@ AWSES.prototype.index = function(options, callback) {
 AWSES.prototype.update = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -228,7 +207,7 @@ AWSES.prototype.update = function(options, callback) {
 
     var path = '/' + options.index + '/' + options.type + '/' + options.id + '/_update';
     self._request(path, options.body, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -236,25 +215,21 @@ AWSES.prototype.update = function(options, callback) {
 AWSES.prototype.bulk = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
     var missing = are_options_missing(options, 'index', 'type');
     if (missing) { return callback(missing); }
 
-    if( !is.existy(options.body) ) return callback('not_body');
-    if( !is.array(options.body) || (options.body.length == 0) ) return callback('invalid_body');
+    if (!is.existy(options.body)) return callback('not_body');
+    if (!is.array(options.body) || (options.body.length == 0)) return callback('invalid_body');
 
     var path = '/' + options.index + '/' + options.type + '/_bulk';
     self._request(path, options.body, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -262,13 +237,9 @@ AWSES.prototype.bulk = function(options, callback) {
 AWSES.prototype.search = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -276,21 +247,21 @@ AWSES.prototype.search = function(options, callback) {
     var missing = are_options_missing(options, 'index', 'type', 'body');
     if (missing) { return callback(missing); }
 
-    if( is.existy(options.scroll) && !is.string(options.scroll) ) return callback('invalid_scroll');
-    if( is.existy(options.searchType) && !is.string(options.searchType) ) return callback('invalid_searchType');
-    if( is.existy(options.defaultOperator) && !is.string(options.defaultOperator) ) return callback('invalid_defaultOperator');
-    if( is.existy(options.size) && !is.integer(options.size) ) return callback('invalid_size');
-    if( is.existy(options.from) && !is.integer(options.from) ) return callback('invalid_from');
-    if( is.existy(options.sort) && !is.string(options.sort) ) return callback('invalid_sort');
+    if (is.existy(options.scroll) && !is.string(options.scroll)) return callback('invalid_scroll');
+    if (is.existy(options.searchType) && !is.string(options.searchType)) return callback('invalid_searchType');
+    if (is.existy(options.defaultOperator) && !is.string(options.defaultOperator)) return callback('invalid_defaultOperator');
+    if (is.existy(options.size) && !is.integer(options.size)) return callback('invalid_size');
+    if (is.existy(options.from) && !is.integer(options.from)) return callback('invalid_from');
+    if (is.existy(options.sort) && !is.string(options.sort)) return callback('invalid_sort');
 
     var qs = {};
-    if(options.scroll) qs.scroll = options.scroll;
-    if(options.searchType) qs.search_type = options.searchType;
-    if(options.size) qs.size = options.size;
-    if(options.from) qs.from = options.from;
-    if(options.sort) qs.sort = options.sort;
+    if (options.scroll) qs.scroll = options.scroll;
+    if (options.searchType) qs.search_type = options.searchType;
+    if (options.size) qs.size = options.size;
+    if (options.from) qs.from = options.from;
+    if (options.sort) qs.sort = options.sort;
 
-    if( is.existy(options.defaultOperator) && is.existy(options.body)
+    if (is.existy(options.defaultOperator) && is.existy(options.body)
         && is.existy(options.body.query) && is.existy(options.body.query.query_string))
         options.body.query.query_string.default_operator = options.defaultOperator;
 
@@ -298,7 +269,7 @@ AWSES.prototype.search = function(options, callback) {
     path += '/?' + querystring.stringify(qs);
 
     self._request(path, options.body, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -306,13 +277,9 @@ AWSES.prototype.search = function(options, callback) {
 AWSES.prototype.scroll = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -323,7 +290,7 @@ AWSES.prototype.scroll = function(options, callback) {
     var path = '/_search/scroll?scroll=' + options.scroll + '&scroll_id=' + options.scrollId;
 
     self._request(path, null, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -331,13 +298,9 @@ AWSES.prototype.scroll = function(options, callback) {
 AWSES.prototype.get = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -347,7 +310,7 @@ AWSES.prototype.get = function(options, callback) {
 
     var path = '/' + options.index + '/' + options.type + '/' + options.id;
     self._request(path, null, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -355,13 +318,9 @@ AWSES.prototype.get = function(options, callback) {
 AWSES.prototype.mget = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -371,7 +330,7 @@ AWSES.prototype.mget = function(options, callback) {
 
     var path = '/' + options.index + '/' + options.type + '/_mget';
     self._request(path, options.body, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -379,13 +338,9 @@ AWSES.prototype.mget = function(options, callback) {
 AWSES.prototype.delete = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -393,20 +348,20 @@ AWSES.prototype.delete = function(options, callback) {
     var missing = are_options_missing(options, 'index');
     if (missing) { return callback(missing); }
 
-    if( is.existy(options.type) && !is.string(options.type) ) return callback('invalid_type');
+    if (is.existy(options.type) && !is.string(options.type)) return callback('invalid_type');
 
-    if( is.existy(options.type) && is.existy(options.id) && !is.string(options.id) ) return callback('invalid_id');
+    if (is.existy(options.type) && is.existy(options.id) && !is.string(options.id)) return callback('invalid_id');
 
     var path = '/' + options.index;
 
-    if(options.type)
+    if (options.type)
         path += '/'+options.type;
 
-    if(options.id)
+    if (options.id)
         path += '/'+options.id;
 
     self._request(path, null, {method: 'DELETE'}, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -414,13 +369,9 @@ AWSES.prototype.delete = function(options, callback) {
 AWSES.prototype.putMapping = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -434,7 +385,7 @@ AWSES.prototype.putMapping = function(options, callback) {
 
     path += '/_mapping/'+options.type;
     self._request(path, options.body, {method: 'POST'}, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };
@@ -442,13 +393,9 @@ AWSES.prototype.putMapping = function(options, callback) {
 AWSES.prototype.getMapping = function(options, callback) {
     var self = this;
 
-    if( !is.existy(callback) )
-    {
-        if(is.function(options))
-        {
-            callback = options;
-            options = null;
-        }
+    if (!is.existy(callback) && is.function(options)) {
+        callback = options;
+        options = null;
     }
 
     validate_callback(callback);
@@ -462,7 +409,7 @@ AWSES.prototype.getMapping = function(options, callback) {
 
     path += '/_mapping/'+options.type;
     self._request(path, options.body, {method: 'GET'}, function(err, data) {
-        if(err) return callback(err);
+        if (err) return callback(err);
         return callback(null, data);
     });
 };

--- a/test/lib/aws-esSpec.js
+++ b/test/lib/aws-esSpec.js
@@ -266,6 +266,43 @@ describe('aws-es', function() {
 				});
 			});
 		});
+
+		it('creates an index with a mapping using .indices', function(done) {
+			var mapping = {
+				mappings: {
+					bananas: {
+						properties: {
+							pajamas: {
+								type: 'string',
+								index: 'not_analyzed'
+							}
+						}
+					}
+				}
+			};
+			elasticsearch.indices.create({
+				index: index,
+				body: mapping
+			}, function(err, data) {
+				elasticsearch.indices.getMapping({
+					index: index,
+					type: ''
+				}, function(err, data) {
+					expect(data[index]).deep.equal(mapping);
+					elasticsearch.indices.exists({
+						index: index
+					}, function(err, data) {
+						expect(data).equal(true);
+						elasticsearch.indices.exists({
+							index: 'bananas'
+						}, function(err, data) {
+							expect(data).equals(false);
+							done();
+						});
+					});
+				});
+			});
+		});
 	});
 
     describe('count', function() {

--- a/test/lib/aws-esSpec.js
+++ b/test/lib/aws-esSpec.js
@@ -411,6 +411,7 @@ describe('aws-es', function() {
             elasticsearch.index({
 				index: INDEX,
 				type: TYPE,
+				body: {},
 				id: 1
 			}, function(err, data) {
                 expect(err).to.be.equal('invalid_id');
@@ -513,6 +514,7 @@ describe('aws-es', function() {
 		it('should return an error for no id', function() {
             elasticsearch.update({
 				index: INDEX,
+				body: {},
 				type: TYPE
 			}, function(err, data) {
                 expect(err).to.be.equal('not_id');
@@ -523,6 +525,7 @@ describe('aws-es', function() {
             elasticsearch.update({
 				index: INDEX,
 				type: TYPE,
+				body: {},
 				id: 1
 			}, function(err, data) {
                 expect(err).to.be.equal('invalid_id');


### PR DESCRIPTION
Add a `.indices` object to the client with `create`, `delete`, `getMapping`, and `exists` APIs. This will enable us to drop this client into the Juttle Elastic Adapter without any `client instanceof AmazonElasticsearchClient` checks.

Also, perform some much-needed code cleanup.

unblocks https://github.com/juttle/juttle-elastic-adapter/issues/96

@VladVega 
